### PR TITLE
feat: hooks refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ app.register(mercuriusGateway, {
 
 ## Hooks
 
-Hooks are registered with the `fastify.graphql.gateway.addHook` method 
+Hooks are registered with the `fastify.graphqlGateway.addHook` method 
 and allow you to listen to specific events in the GraphQL request/response lifecycle. 
 You have to register a hook before the event is triggered, otherwise the event is lost.
 
@@ -312,7 +312,7 @@ Note, this hook contains service metadata in the `service` parameter:
 - `name`: service name
 
 ```js
-fastify.graphql.gateway.addHook('preGatewayExecution', async (schema, document, context, service) => {
+fastify.graphqlGateway.addHook('preGatewayExecution', async (schema, document, context, service) => {
   const { modifiedDocument, errors } = await asyncMethod(document)
 
   return {
@@ -327,7 +327,7 @@ If you get an error during the execution of your hook, you can just throw an err
 The `preGatewayExecution` hook, which will continue execution of the rest of the query and append the error to the errors array in the response.
 
 ```js
-fastify.graphql.gateway.addHook('preGatewayExecution', async (schema, document, context, service) => {
+fastify.graphqlGateway.addHook('preGatewayExecution', async (schema, document, context, service) => {
   throw new Error('Some error')
 })
 ```
@@ -337,7 +337,7 @@ fastify.graphql.gateway.addHook('preGatewayExecution', async (schema, document, 
 The `preGatewayExecution` hook support adding errors to the GraphQL response.
 
 ```js
-fastify.graphql.gateway.addHook('preGatewayExecution', async (schema, document, context) => {
+fastify.graphqlGateway.addHook('preGatewayExecution', async (schema, document, context) => {
   return {
     errors: [new Error('foo')]
   }
@@ -371,7 +371,7 @@ Note, this hook contains service metadata in the `service` parameter:
 - `name`: service name
 
 ```js
-fastify.graphql.gateway.addHook('preGatewaySubscriptionExecution', async (schema, document, context, service) => {
+fastify.graphqlGateway.addHook('preGatewaySubscriptionExecution', async (schema, document, context, service) => {
   await asyncMethod()
 })
 ```
@@ -381,7 +381,7 @@ fastify.graphql.gateway.addHook('preGatewaySubscriptionExecution', async (schema
 If you get an error during the execution of your subscription hook, you can just throw an error and Mercurius will send the appropriate errors to the user along the websocket.`
 
 ```js
-fastify.graphql.gateway.addHook('preSubscriptionParsing', async (schema, source, context) => {
+fastify.graphqlGateway.addHook('preSubscriptionParsing', async (schema, source, context) => {
   throw new Error('Some error')
 })
 ```
@@ -400,7 +400,7 @@ It has the following parameters:
 - `schema` - The new schema that has been built from the gateway refresh.
 
 ```js
-fastify.graphql.gateway.addHook('onGatewayReplaceSchema', async (instance, schema) => {
+fastify.graphqlGateway.addHook('onGatewayReplaceSchema', async (instance, schema) => {
   await someSchemaTraversalFn()
 })
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,79 @@
 import { FastifyInstance, FastifyReply } from 'fastify'
-import { MercuriusContext, MercuriusOptions } from 'mercurius'
+import { MercuriusContext, MercuriusPlugin, MercuriusOptions, PreExecutionHookResponse } from 'mercurius'
 import { IncomingHttpHeaders, OutgoingHttpHeaders } from "http"
+
+import {
+  DocumentNode,
+  GraphQLSchema,
+  ExecutionResult,
+} from "graphql";
+
+interface ServiceConfig {
+  setSchema: (schema: string) => ServiceConfig;
+}
+
+interface Gateway {
+  refresh: (isRetry?: boolean) => Promise<GraphQLSchema | null>;
+  serviceMap: Record<string, ServiceConfig>;
+
+  /**
+   * `preGatewayExecution` is the hook to be executed in the GraphQL gateway request lifecycle.
+   * The previous hook was `preExecution`, the next hook will be `onResolution`.
+   * Notice: in the `preGatewayExecution` hook, you can modify the following items by returning them in the hook definition:
+   *  - `document`
+   *  - `errors`
+   * Each hook definition will trigger multiple times in a single request just before executing remote GraphQL queries on the federated services.
+   */
+  addHook<TContext = MercuriusContext, TError extends Error = Error>(name: 'preGatewayExecution', hook: preGatewayExecutionHookHandler<TContext, TError>): void;
+
+  /**
+   * `preGatewaySubscriptionExecution` is the hook to be executed in the GraphQL gateway subscription lifecycle.
+   * The previous hook was `preSubscriptionExecution`, the next hook will be `onSubscriptionResolution`.
+   */
+  addHook<TContext = MercuriusContext>(name: 'preGatewaySubscriptionExecution', hook: preGatewaySubscriptionExecutionHookHandler<TContext>): void;
+
+  /**
+   * `onGatewayReplaceSchema` is an application lifecycle hook. When the Gateway service obtains new versions of federated schemas within a defined polling interval, the `onGatewayReplaceSchema` hook will be triggered every time a new schema is built. It is called just before the old schema is replaced with the new one.
+   * This hook will only be triggered in gateway mode. It has the following parameters:
+   *  - `instance` - The gateway server `FastifyInstance` (this contains the old schema).
+   *  - `schema` - The new schema that has been built from the gateway refresh.
+   */
+  addHook(name: 'onGatewayReplaceSchema', hook: onGatewayReplaceSchemaHookHandler): void;
+}
+
+declare module "fastify" {
+  interface FastifyInstance {
+    /**
+     * GraphQL plugin
+     */
+    graphqlGateway: Gateway
+  }
+
+  interface FastifyReply {
+    /**
+     * @param source GraphQL query string
+     * @param context request context
+     * @param variables request variables which will get passed to the executor
+     * @param operationName specify which operation will be run
+     */
+    graphql<
+      TData extends Record<string, any> = Record<string, any>,
+      TVariables extends Record<string, any> = Record<string, any>
+      >(
+      source: string,
+      context?: Record<string, any>,
+      variables?: TVariables,
+      operationName?: string
+    ): Promise<ExecutionResult<TData>>;
+  }
+}
+
+/**
+ * Federated GraphQL Service metadata
+ */
+export interface MercuriusServiceMetadata {
+  name: string;
+}
 
 interface WsConnectionParams {
   connectionInitPayload?:
@@ -55,3 +128,64 @@ declare const mercuriusGatewayPlugin: (
 ) => void
 
 export default mercuriusGatewayPlugin;
+
+// ------------------------
+// Request Lifecycle hooks
+// ------------------------
+
+/**
+ * `preGatewayExecution` is the hook to be executed in the GraphQL gateway request lifecycle.
+ * The previous hook was `preExecution`, the next hook will be `onResolution`.
+ * Notice: in the `preGatewayExecution` hook, you can modify the following items by returning them in the hook definition:
+ *  - `document`
+ *  - `errors`
+ * Each hook definition will trigger multiple times in a single request just before executing remote GraphQL queries on the federated services.
+ *
+ * Because it is a gateway hook, this hook contains service metadata in the `service` parameter:
+ *  - `name`: service name
+ */
+export interface preGatewayExecutionHookHandler<TContext = MercuriusContext, TError extends Error = Error> {
+  (
+    schema: GraphQLSchema,
+    source: DocumentNode,
+    context: TContext,
+    service: MercuriusServiceMetadata
+  ): Promise<PreExecutionHookResponse<TError> | void> | PreExecutionHookResponse<TError> | void;
+}
+
+// -----------------------------
+// Subscription Lifecycle hooks
+// -----------------------------
+
+/**
+ * `preGatewaySubscriptionExecution` is the hook to be executed in the GraphQL gateway subscription lifecycle.
+ * The previous hook was `preSubscriptionExecution`, the next hook will be `onSubscriptionResolution`.
+ *
+ *  Because it is a gateway hook, this hook contains service metadata in the `service` parameter:
+ *  - `name`: service name
+ */
+export interface preGatewaySubscriptionExecutionHookHandler<TContext = MercuriusContext> {
+  (
+    schema: GraphQLSchema,
+    source: DocumentNode,
+    context: TContext,
+    service: MercuriusServiceMetadata
+  ): Promise<void> | void;
+}
+
+// ----------------------------
+// Application Lifecycle hooks
+// ----------------------------
+
+/**
+ * `onGatewayReplaceSchema` is an application lifecycle hook. When the Gateway service obtains new versions of federated schemas within a defined polling interval, the `onGatewayReplaceSchema` hook will be triggered every time a new schema is built. It is called just before the old schema is replaced with the new one.
+ * This hook will only be triggered in gateway mode. It has the following parameters:
+ *  - `instance` - The gateway server `FastifyInstance` (this contains the old schema).
+ *  - `schema` - The new schema that has been built from the gateway refresh.
+ */
+export interface onGatewayReplaceSchemaHookHandler {
+  (
+    instance: FastifyInstance,
+    schema: GraphQLSchema
+  ): Promise<void> | void;
+}

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,9 +1,43 @@
 'use strict'
 
+const { GraphQLError } = require('graphql')
 const createError = require('@fastify/error')
-const mercuriusError = require('mercurius/lib/errors')
 
 const FEDERATED_ERROR = Symbol('FEDERATED_ERROR')
+
+function addErrorsToContext (context, errors) {
+  let newErrors
+  if (context.errors !== null) {
+    newErrors = context.errors.concat(errors)
+  } else {
+    newErrors = errors
+  }
+
+  context.errors = newErrors
+}
+
+// converts an error to a `GraphQLError` compatible
+// allows to copy the `path` & `locations` properties
+// from the already serialized error
+function toGraphQLError (err) {
+  if (err instanceof GraphQLError) {
+    return err
+  }
+
+  const gqlError = new GraphQLError(
+    err.message,
+    err.nodes,
+    err.source,
+    err.positions,
+    err.path,
+    err,
+    err.extensions
+  )
+
+  gqlError.locations = err.locations
+
+  return gqlError
+}
 
 // a specialized `Error` which extends the `Error` built-in
 // to satisfy the `graphql` error handler
@@ -18,6 +52,42 @@ class FederatedError extends Error {
 }
 
 const errors = {
+  /**
+   * General errors
+   * Replicated from `mercurius`.
+   * TODO: export the errors from mercurius
+   */
+  MER_ERR_INVALID_OPTS: createError(
+    'MER_ERR_INVALID_OPTS',
+    'Invalid options: %s'
+  ),
+  /**
+   * Hooks errors
+   * Replicated from `mercurius`.
+   * TODO: export the errors from mercurius
+   */
+  MER_ERR_HOOK_INVALID_TYPE: createError(
+    'MER_ERR_HOOK_INVALID_TYPE',
+    'The hook name must be a string',
+    500,
+    TypeError
+  ),
+  MER_ERR_HOOK_INVALID_HANDLER: createError(
+    'MER_ERR_HOOK_INVALID_HANDLER',
+    'The hook callback must be a function',
+    500,
+    TypeError
+  ),
+  MER_ERR_HOOK_UNSUPPORTED_HOOK: createError(
+    'MER_ERR_HOOK_UNSUPPORTED_HOOK',
+    '%s hook not supported!',
+    500
+  ),
+  MER_ERR_SERVICE_RETRY_FAILED: createError(
+    'MER_ERR_SERVICE_RETRY_FAILED',
+    'Mandatory services retry failed - [%s]',
+    500
+  ),
   /**
    * Gateway errors
    */
@@ -55,13 +125,13 @@ function defaultErrorFormatter (execution, ctx) {
 
     // parses, converts & combines errors if they are the result of a federated request
     if (error.message === FEDERATED_ERROR.toString() && error.extensions) {
-      return error.extensions.errors.map(err => mercuriusError.toGraphQLError(err))
+      return error.extensions.errors.map(err => toGraphQLError(err))
     }
 
     // it handles fastify errors MER_ERR_GQL_VALIDATION
     if (error.originalError?.errors) {
       // not all errors are `GraphQLError` type, we need to convert them
-      return error.originalError.errors.map(mercuriusError.toGraphQLError)
+      return error.originalError.errors.map(toGraphQLError)
     }
 
     return error
@@ -92,4 +162,4 @@ function defaultErrorFormatter (execution, ctx) {
   }
 }
 
-module.exports = { ...mercuriusError, ...errors, defaultErrorFormatter, FederatedError }
+module.exports = { ...errors, defaultErrorFormatter, FederatedError, addErrorsToContext }

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -6,12 +6,14 @@ const {
   MER_ERR_GQL_GATEWAY,
   MER_ERR_GQL_GATEWAY_INIT
 } = require('./errors')
-const { kHooks } = require('mercurius/lib/symbols')
+
 const {
-  onGatewayReplaceSchemaHandler,
-  assignApplicationLifecycleHooksToContext
+  onGatewayReplaceSchemaHandler
 } = require('./handlers')
 const { buildCache } = require('./util')
+const { Hooks, assignLifeCycleHooksToContext, assignApplicationLifecycleHooksToContext } = require('./hooks')
+
+const kGatewayHooks = Symbol('mercurius.gateway.hooks')
 
 function validateGateway (opts) {
   const gateway = opts
@@ -75,6 +77,13 @@ async function createGateway (gatewayOpts, app) {
       lruGatewayResolvers
     )
 
+    gateway[kGatewayHooks] = new Hooks()
+
+    // Wrapper that we expose to the user for GraphQL hooks handling
+    gateway.addHook = function (name, fn) {
+      gateway[kGatewayHooks].add(name, fn)
+    }
+
     app.graphql.replaceSchema(gateway.schema)
 
     let gatewayInterval
@@ -131,7 +140,7 @@ async function createGateway (gatewayOpts, app) {
           try {
             const context = assignApplicationLifecycleHooksToContext(
               {},
-              fastifyGraphQl[kHooks]
+              gateway[kGatewayHooks]
             )
             const schema = await gateway.refresh()
             if (schema !== null) {
@@ -183,7 +192,7 @@ async function createGateway (gatewayOpts, app) {
 
           const context = assignApplicationLifecycleHooksToContext(
             {},
-            fastifyGraphQl[kHooks]
+            gateway[kGatewayHooks]
           )
 
           const schema = await gateway.refresh(isRetry)
@@ -211,6 +220,16 @@ async function createGateway (gatewayOpts, app) {
         }
       }, interval)
     }
+
+    fastifyGraphQl.addHook('preExecution', async (schema, document, context) => {
+      context.gateway = assignApplicationLifecycleHooksToContext(assignLifeCycleHooksToContext(gateway, gateway[kGatewayHooks]), gateway[kGatewayHooks])
+    })
+
+    fastifyGraphQl.addHook('preSubscriptionExecution', async (schema, document, context) => {
+      context.gateway = assignApplicationLifecycleHooksToContext(assignLifeCycleHooksToContext(gateway, gateway[kGatewayHooks]), gateway[kGatewayHooks])
+    })
+
+    return gateway
   } catch (e) {
     for (const service of Object.values(serviceMap)) {
       /* istanbul ignore next */

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -106,8 +106,9 @@ async function createGateway (gatewayOpts, app) {
       return gateway.close()
     }
 
+    app.decorate('graphqlGateway', gateway)
+
     const fastifyGraphQl = app.graphql
-    fastifyGraphQl.gateway = gateway
     const failedMandatoryServices = Object.values(gateway.serviceMap).filter(
       service => !!service.error && service.mandatory
     )

--- a/lib/gateway/get-query-result.js
+++ b/lib/gateway/get-query-result.js
@@ -58,7 +58,7 @@ async function fetchBatchedResult ({
   )) {
     let modifiedQuery
 
-    if (context.preGatewayExecution !== null) {
+    if (context.gateway.preGatewayExecution !== null) {
       ;({ modifiedQuery } = await preGatewayExecutionHandler({
         schema: serviceDefinition.schema,
         document,
@@ -140,7 +140,7 @@ async function fetchResult ({
     queriesEntries.map(async ([query, { document, variables }]) => {
       let modifiedQuery
 
-      if (context.preGatewayExecution !== null) {
+      if (context.gateway.preGatewayExecution !== null) {
         ;({ modifiedQuery } = await preGatewayExecutionHandler({
           schema: serviceDefinition.schema,
           document,

--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -585,8 +585,7 @@ function makeResolver ({
     }
 
     if (isSubscription) {
-      // Trigger preGatewaySubscriptionExecution hook
-      if (context.preGatewaySubscriptionExecution !== null) {
+      if (context.gateway.preGatewaySubscriptionExecution !== null) {
         await preGatewaySubscriptionExecutionHandler({
           schema,
           document: operation,
@@ -609,7 +608,8 @@ function makeResolver ({
     if (isQuery) {
       // Trigger preGatewayExecution hook
       let modifiedQuery
-      if (context.preGatewayExecution !== null) {
+
+      if (context.gateway.preGatewayExecution !== null) {
         ;({ modifiedQuery } = await preGatewayExecutionHandler({
           schema,
           document: operation,

--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -13,6 +13,8 @@ const {
 } = require('graphql')
 
 const { buildRequest, sendRequest } = require('./request')
+
+// TODO: export subscription client from Mercurius to avoid an internal reference
 const SubscriptionClient = require('mercurius/lib/subscription-client')
 const { MER_ERR_GQL_GATEWAY_INIT } = require('../errors')
 const { buildFederationSchema } = require('@mercuriusjs/federation')

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -3,7 +3,7 @@
 const { print } = require('graphql')
 
 const { addErrorsToContext } = require('./errors')
-const { hooksRunner } = require('mercurius/lib/hooks')
+const { hooksRunner } = require('./hooks')
 
 function gatewayHookRunner (fn, request) {
   return fn(request.schema, request.document, request.context, request.service)
@@ -11,14 +11,6 @@ function gatewayHookRunner (fn, request) {
 
 function onGatewayReplaceSchemaHookRunner (fn, data) {
   return fn(data.instance, data.schema)
-}
-
-function assignApplicationLifecycleHooksToContext (context, hooks) {
-  const contextHooks = {
-    onGatewayReplaceSchema: null
-  }
-  if (hooks.onGatewayReplaceSchema.length > 0) { contextHooks.onGatewayReplaceSchema = hooks.onGatewayReplaceSchema.slice() }
-  return Object.assign(context, contextHooks)
 }
 
 async function onGatewayReplaceSchemaHandler (context, data) {
@@ -56,7 +48,7 @@ async function preGatewayExecutionHooksRunner (functions, request) {
 
 async function preGatewayExecutionHandler (request) {
   const { errors, modifiedDocument } = await preGatewayExecutionHooksRunner(
-    request.context.preGatewayExecution,
+    request.context.gateway.preGatewayExecution,
     request
   )
   if (errors.length > 0) {
@@ -73,14 +65,13 @@ async function preGatewayExecutionHandler (request) {
 
 async function preGatewaySubscriptionExecutionHandler (request) {
   await hooksRunner(
-    request.context.preGatewaySubscriptionExecution,
+    request.context.gateway.preGatewaySubscriptionExecution,
     gatewayHookRunner,
     request
   )
 }
 
 module.exports = {
-  assignApplicationLifecycleHooksToContext,
   onGatewayReplaceSchemaHandler,
   preGatewayExecutionHandler,
   preGatewaySubscriptionExecutionHandler

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const applicationHooks = [
+  'onGatewayReplaceSchema'
+]
+const lifecycleHooks = [
+  'preGatewayExecution',
+  'preGatewaySubscriptionExecution'
+]
+
+const supportedHooks = lifecycleHooks.concat(applicationHooks)
+
+const { MER_ERR_HOOK_INVALID_TYPE, MER_ERR_HOOK_INVALID_HANDLER, MER_ERR_HOOK_UNSUPPORTED_HOOK } = require('./errors')
+
+function Hooks () {
+  this.preGatewayExecution = []
+  this.preGatewaySubscriptionExecution = []
+  this.onGatewayReplaceSchema = []
+}
+
+Hooks.prototype.validate = function (hook, fn) {
+  if (typeof hook !== 'string') throw new MER_ERR_HOOK_INVALID_TYPE()
+  if (typeof fn !== 'function') throw new MER_ERR_HOOK_INVALID_HANDLER()
+  if (supportedHooks.indexOf(hook) === -1) {
+    throw new MER_ERR_HOOK_UNSUPPORTED_HOOK(hook)
+  }
+}
+
+Hooks.prototype.add = function (hook, fn) {
+  this.validate(hook, fn)
+  this[hook].push(fn)
+}
+
+function assignApplicationLifecycleHooksToContext (context, hooks) {
+  const contextHooks = {
+    onGatewayReplaceSchema: null
+  }
+  if (hooks.onGatewayReplaceSchema.length > 0) contextHooks.onGatewayReplaceSchema = hooks.onGatewayReplaceSchema.slice()
+  return Object.assign(context, contextHooks)
+}
+
+function assignLifeCycleHooksToContext (context, hooks) {
+  const contextHooks = {
+    preGatewayExecution: null,
+    preGatewaySubscriptionExecution: null
+  }
+  if (hooks.preGatewayExecution.length > 0) contextHooks.preGatewayExecution = hooks.preGatewayExecution.slice()
+  if (hooks.preGatewaySubscriptionExecution.length > 0) contextHooks.preGatewaySubscriptionExecution = hooks.preGatewaySubscriptionExecution.slice()
+  return Object.assign(context, contextHooks)
+}
+
+async function hooksRunner (functions, runner, request) {
+  for (const fn of functions) {
+    await runner(fn, request)
+  }
+}
+
+module.exports = {
+  Hooks,
+  assignLifeCycleHooksToContext,
+  assignApplicationLifecycleHooksToContext,
+  hooksRunner
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:typescript:fix": "standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin test/types/*.ts --fix",
     "example": "node example/index.js",
     "test": "npm run lint && npm run test:types && npm run test:unit ",
-    "test:unit": "tap --jobs=1 --coverage-report=html test/*.js",
+    "test:unit": "tap --coverage-report=html test/*.js",
     "test:types": "tsd",
     "prepare": "husky install"
   },
@@ -48,7 +48,7 @@
     "sinon": "^14.0.2",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
-    "tap": "16.3.0",
+    "tap": "^16.3.2",
     "tsd": "^0.24.1"
   },
   "tsd": {

--- a/test/application-hooks.js
+++ b/test/application-hooks.js
@@ -82,7 +82,7 @@ test('onGatewayReplaceSchema - polling interval with a new schema should trigger
     }
   })
 
-  gateway.graphql.addHook(
+  gateway.graphql.gateway.addHook(
     'onGatewayReplaceSchema',
     async (instance, schema) => {
       t.type(instance, 'object')
@@ -170,12 +170,12 @@ test('onGatewayReplaceSchema - should log an error should any errors occur in th
     }
   })
 
-  gateway.graphql.addHook('onGatewayReplaceSchema', async () => {
+  gateway.graphql.gateway.addHook('onGatewayReplaceSchema', async () => {
     t.ok('trigger error')
     throw new Error('kaboom')
   })
 
-  gateway.graphql.addHook('onGatewayReplaceSchema', async () => {
+  gateway.graphql.gateway.addHook('onGatewayReplaceSchema', async () => {
     t.fail('should not be called')
   })
 

--- a/test/application-hooks.js
+++ b/test/application-hooks.js
@@ -82,7 +82,7 @@ test('onGatewayReplaceSchema - polling interval with a new schema should trigger
     }
   })
 
-  gateway.graphql.gateway.addHook(
+  gateway.graphqlGateway.addHook(
     'onGatewayReplaceSchema',
     async (instance, schema) => {
       t.type(instance, 'object')
@@ -170,12 +170,12 @@ test('onGatewayReplaceSchema - should log an error should any errors occur in th
     }
   })
 
-  gateway.graphql.gateway.addHook('onGatewayReplaceSchema', async () => {
+  gateway.graphqlGateway.addHook('onGatewayReplaceSchema', async () => {
     t.ok('trigger error')
     throw new Error('kaboom')
   })
 
-  gateway.graphql.gateway.addHook('onGatewayReplaceSchema', async () => {
+  gateway.graphqlGateway.addHook('onGatewayReplaceSchema', async () => {
     t.fail('should not be called')
   })
 

--- a/test/get-query-result.js
+++ b/test/get-query-result.js
@@ -55,7 +55,9 @@ test('it works with a basic example', async t => {
   const entity2 = createEntity('p2')
   const result = await getQueryResult({
     context: {
-      preGatewayExecution: null,
+      gateway: {
+        preGatewayExecution: null
+      },
       reply: {
         request: {
           headers: {}
@@ -91,7 +93,9 @@ test('it works with a basic example and batched queries', async t => {
   const entity2 = createEntity('p4')
   const result = await getQueryResult({
     context: {
-      preGatewayExecution: null,
+      gateway: {
+        preGatewayExecution: null
+      },
       reply: {
         request: {
           headers: {}

--- a/test/hooks-with-batching.js
+++ b/test/hooks-with-batching.js
@@ -220,7 +220,7 @@ test('gateway - hooks', async t => {
   //  - once for post service query
   //  - once for reference type topPosts on User
   //  - once for reference type author on Post
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context) {
       await immediate()
@@ -293,7 +293,7 @@ test('gateway - hooks validation should handle invalid hook name types', async t
   const app = await createTestGatewayServer(t)
 
   try {
-    app.graphql.addHook(1, async () => {})
+    app.graphql.gateway.addHook(1, async () => {})
   } catch (e) {
     t.equal(e.code, 'MER_ERR_HOOK_INVALID_TYPE')
     t.equal(e.message, 'The hook name must be a string')
@@ -305,7 +305,7 @@ test('gateway - hooks validation should handle invalid hook handlers', async t =
   const app = await createTestGatewayServer(t)
 
   try {
-    app.graphql.addHook('preParsing', 'not a function')
+    app.graphql.gateway.addHook('onGatewayReplaceSchema', 'not a function')
   } catch (e) {
     t.equal(e.code, 'MER_ERR_HOOK_INVALID_HANDLER')
     t.equal(e.message, 'The hook callback must be a function')
@@ -352,7 +352,7 @@ test('gateway - hooks should trigger when JIT is enabled', async t => {
   //  - once for post service query
   //  - once for reference type topPosts on User
   //  - once for reference type author on Post
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context) {
       await immediate()
@@ -878,7 +878,7 @@ test('gateway - preGatewayExecution hooks should handle errors', async t => {
   t.plan(10)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -888,7 +888,7 @@ test('gateway - preGatewayExecution hooks should handle errors', async t => {
     }
   )
 
-  app.graphql.addHook('preGatewayExecution', async () => {
+  app.graphql.gateway.addHook('preGatewayExecution', async () => {
     t.fail('this should not be called')
   })
 
@@ -930,7 +930,7 @@ test('gateway - preGatewayExecution hooks should be able to put values onto the 
   t.plan(29)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -940,7 +940,7 @@ test('gateway - preGatewayExecution hooks should be able to put values onto the 
     }
   )
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -993,7 +993,7 @@ test('gateway - preGatewayExecution hooks should be able to add to the errors ar
   t.plan(33)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1006,7 +1006,7 @@ test('gateway - preGatewayExecution hooks should be able to add to the errors ar
     }
   )
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1088,7 +1088,7 @@ test('gateway - preGatewayExecution hooks should be able to modify the request d
   t.plan(17)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1152,7 +1152,7 @@ test('gateway - preGatewayExecution hooks should contain service metadata', asyn
   //  - post service: once for post service query
   //  - post service: once for reference type topPosts on User
   //  - user service: once for reference type author on Post
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context, service) {
       await immediate()

--- a/test/hooks-with-batching.js
+++ b/test/hooks-with-batching.js
@@ -220,7 +220,7 @@ test('gateway - hooks', async t => {
   //  - once for post service query
   //  - once for reference type topPosts on User
   //  - once for reference type author on Post
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context) {
       await immediate()
@@ -293,7 +293,7 @@ test('gateway - hooks validation should handle invalid hook name types', async t
   const app = await createTestGatewayServer(t)
 
   try {
-    app.graphql.gateway.addHook(1, async () => {})
+    app.graphqlGateway.addHook(1, async () => {})
   } catch (e) {
     t.equal(e.code, 'MER_ERR_HOOK_INVALID_TYPE')
     t.equal(e.message, 'The hook name must be a string')
@@ -305,7 +305,7 @@ test('gateway - hooks validation should handle invalid hook handlers', async t =
   const app = await createTestGatewayServer(t)
 
   try {
-    app.graphql.gateway.addHook('onGatewayReplaceSchema', 'not a function')
+    app.graphqlGateway.addHook('onGatewayReplaceSchema', 'not a function')
   } catch (e) {
     t.equal(e.code, 'MER_ERR_HOOK_INVALID_HANDLER')
     t.equal(e.message, 'The hook callback must be a function')
@@ -352,7 +352,7 @@ test('gateway - hooks should trigger when JIT is enabled', async t => {
   //  - once for post service query
   //  - once for reference type topPosts on User
   //  - once for reference type author on Post
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context) {
       await immediate()
@@ -878,7 +878,7 @@ test('gateway - preGatewayExecution hooks should handle errors', async t => {
   t.plan(10)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -888,7 +888,7 @@ test('gateway - preGatewayExecution hooks should handle errors', async t => {
     }
   )
 
-  app.graphql.gateway.addHook('preGatewayExecution', async () => {
+  app.graphqlGateway.addHook('preGatewayExecution', async () => {
     t.fail('this should not be called')
   })
 
@@ -930,7 +930,7 @@ test('gateway - preGatewayExecution hooks should be able to put values onto the 
   t.plan(29)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -940,7 +940,7 @@ test('gateway - preGatewayExecution hooks should be able to put values onto the 
     }
   )
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -993,7 +993,7 @@ test('gateway - preGatewayExecution hooks should be able to add to the errors ar
   t.plan(33)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1006,7 +1006,7 @@ test('gateway - preGatewayExecution hooks should be able to add to the errors ar
     }
   )
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1088,7 +1088,7 @@ test('gateway - preGatewayExecution hooks should be able to modify the request d
   t.plan(17)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1152,7 +1152,7 @@ test('gateway - preGatewayExecution hooks should contain service metadata', asyn
   //  - post service: once for post service query
   //  - post service: once for reference type topPosts on User
   //  - user service: once for reference type author on Post
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context, service) {
       await immediate()

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -217,7 +217,7 @@ test('gateway - hooks', async t => {
   //  - once for post service query
   //  - once for reference type topPosts on User
   //  - once for reference type author on Post
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context) {
       await immediate()
@@ -279,7 +279,7 @@ test('gateway - hooks validation should handle invalid hook names', async t => {
   const app = await createTestGatewayServer(t)
 
   try {
-    app.graphql.gateway.addHook('unsupportedHook', async () => {})
+    app.graphqlGateway.addHook('unsupportedHook', async () => {})
   } catch (e) {
     t.equal(e.message, 'unsupportedHook hook not supported!')
   }
@@ -290,7 +290,7 @@ test('gateway - hooks validation should handle invalid hook name types', async t
   const app = await createTestGatewayServer(t)
 
   try {
-    app.graphql.gateway.addHook(1, async () => {})
+    app.graphqlGateway.addHook(1, async () => {})
   } catch (e) {
     t.equal(e.code, 'MER_ERR_HOOK_INVALID_TYPE')
     t.equal(e.message, 'The hook name must be a string')
@@ -302,7 +302,7 @@ test('gateway - hooks validation should handle invalid hook handlers', async t =
   const app = await createTestGatewayServer(t)
 
   try {
-    app.graphql.gateway.addHook('preGatewayExecution', 'not a function')
+    app.graphqlGateway.addHook('preGatewayExecution', 'not a function')
   } catch (e) {
     t.equal(e.code, 'MER_ERR_HOOK_INVALID_HANDLER')
     t.equal(e.message, 'The hook callback must be a function')
@@ -349,7 +349,7 @@ test('gateway - hooks should trigger when JIT is enabled', async t => {
   //  - once for post service query
   //  - once for reference type topPosts on User
   //  - once for reference type author on Post
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context) {
       await immediate()
@@ -875,7 +875,7 @@ test('gateway - preGatewayExecution hooks should handle errors', async t => {
   t.plan(10)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -885,7 +885,7 @@ test('gateway - preGatewayExecution hooks should handle errors', async t => {
     }
   )
 
-  app.graphql.gateway.addHook('preGatewayExecution', async () => {
+  app.graphqlGateway.addHook('preGatewayExecution', async () => {
     t.fail('this should not be called')
   })
 
@@ -927,7 +927,7 @@ test('gateway - preGatewayExecution hooks should be able to put values onto the 
   t.plan(29)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -937,7 +937,7 @@ test('gateway - preGatewayExecution hooks should be able to put values onto the 
     }
   )
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -990,7 +990,7 @@ test('gateway - preGatewayExecution hooks should be able to add to the errors ar
   t.plan(33)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1003,7 +1003,7 @@ test('gateway - preGatewayExecution hooks should be able to add to the errors ar
     }
   )
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1085,7 +1085,7 @@ test('gateway - preGatewayExecution hooks should be able to modify the request d
   t.plan(17)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1149,7 +1149,7 @@ test('gateway - preGatewayExecution hooks should contain service metadata', asyn
   //  - post service: once for post service query
   //  - post service: once for reference type topPosts on User
   //  - user service: once for reference type author on Post
-  app.graphql.gateway.addHook(
+  app.graphqlGateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context, service) {
       await immediate()

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -217,7 +217,7 @@ test('gateway - hooks', async t => {
   //  - once for post service query
   //  - once for reference type topPosts on User
   //  - once for reference type author on Post
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context) {
       await immediate()
@@ -279,7 +279,7 @@ test('gateway - hooks validation should handle invalid hook names', async t => {
   const app = await createTestGatewayServer(t)
 
   try {
-    app.graphql.addHook('unsupportedHook', async () => {})
+    app.graphql.gateway.addHook('unsupportedHook', async () => {})
   } catch (e) {
     t.equal(e.message, 'unsupportedHook hook not supported!')
   }
@@ -290,7 +290,7 @@ test('gateway - hooks validation should handle invalid hook name types', async t
   const app = await createTestGatewayServer(t)
 
   try {
-    app.graphql.addHook(1, async () => {})
+    app.graphql.gateway.addHook(1, async () => {})
   } catch (e) {
     t.equal(e.code, 'MER_ERR_HOOK_INVALID_TYPE')
     t.equal(e.message, 'The hook name must be a string')
@@ -302,7 +302,7 @@ test('gateway - hooks validation should handle invalid hook handlers', async t =
   const app = await createTestGatewayServer(t)
 
   try {
-    app.graphql.addHook('preParsing', 'not a function')
+    app.graphql.gateway.addHook('preGatewayExecution', 'not a function')
   } catch (e) {
     t.equal(e.code, 'MER_ERR_HOOK_INVALID_HANDLER')
     t.equal(e.message, 'The hook callback must be a function')
@@ -349,7 +349,7 @@ test('gateway - hooks should trigger when JIT is enabled', async t => {
   //  - once for post service query
   //  - once for reference type topPosts on User
   //  - once for reference type author on Post
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context) {
       await immediate()
@@ -875,7 +875,7 @@ test('gateway - preGatewayExecution hooks should handle errors', async t => {
   t.plan(10)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -885,7 +885,7 @@ test('gateway - preGatewayExecution hooks should handle errors', async t => {
     }
   )
 
-  app.graphql.addHook('preGatewayExecution', async () => {
+  app.graphql.gateway.addHook('preGatewayExecution', async () => {
     t.fail('this should not be called')
   })
 
@@ -927,7 +927,7 @@ test('gateway - preGatewayExecution hooks should be able to put values onto the 
   t.plan(29)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -937,7 +937,7 @@ test('gateway - preGatewayExecution hooks should be able to put values onto the 
     }
   )
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -990,7 +990,7 @@ test('gateway - preGatewayExecution hooks should be able to add to the errors ar
   t.plan(33)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1003,7 +1003,7 @@ test('gateway - preGatewayExecution hooks should be able to add to the errors ar
     }
   )
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1085,7 +1085,7 @@ test('gateway - preGatewayExecution hooks should be able to modify the request d
   t.plan(17)
   const app = await createTestGatewayServer(t)
 
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -1149,7 +1149,7 @@ test('gateway - preGatewayExecution hooks should contain service metadata', asyn
   //  - post service: once for post service query
   //  - post service: once for reference type topPosts on User
   //  - user service: once for reference type author on Post
-  app.graphql.addHook(
+  app.graphql.gateway.addHook(
     'preGatewayExecution',
     async function (schema, document, context, service) {
       await immediate()

--- a/test/pollingInterval.js
+++ b/test/pollingInterval.js
@@ -605,11 +605,11 @@ test('Polling schemas (if service is mandatory, exception should be thrown)', as
     })
   }
 
-  gateway.graphql.gateway.close()
+  gateway.graphqlGateway.close()
   await userService.close()
 
   t.rejects(async () => {
-    await gateway.graphql.gateway.refresh()
+    await gateway.graphqlGateway.refresh()
   })
 })
 

--- a/test/retry-failed-services.js
+++ b/test/retry-failed-services.js
@@ -169,7 +169,7 @@ test('gateway - retry mandatory failed services on startup', async t => {
     jit: 1
   })
 
-  gateway.graphql.addHook(
+  gateway.graphql.gateway.addHook(
     'onGatewayReplaceSchema',
     async (instance, schema) => {
       t.type(instance, 'object')
@@ -473,7 +473,7 @@ test('gateway - should log error if retry throws', async t => {
     jit: 1
   })
 
-  gateway.graphql.addHook('onGatewayReplaceSchema', async () => {
+  gateway.graphql.gateway.addHook('onGatewayReplaceSchema', async () => {
     throw new Error('kaboom')
   })
 

--- a/test/retry-failed-services.js
+++ b/test/retry-failed-services.js
@@ -169,7 +169,7 @@ test('gateway - retry mandatory failed services on startup', async t => {
     jit: 1
   })
 
-  gateway.graphql.gateway.addHook(
+  gateway.graphqlGateway.addHook(
     'onGatewayReplaceSchema',
     async (instance, schema) => {
       t.type(instance, 'object')
@@ -473,7 +473,7 @@ test('gateway - should log error if retry throws', async t => {
     jit: 1
   })
 
-  gateway.graphql.gateway.addHook('onGatewayReplaceSchema', async () => {
+  gateway.graphqlGateway.addHook('onGatewayReplaceSchema', async () => {
     throw new Error('kaboom')
   })
 

--- a/test/schema_4.js
+++ b/test/schema_4.js
@@ -457,8 +457,8 @@ test('Update the schema', async t => {
     'Cannot query field "world" on type "Query".'
   )
 
-  gateway.graphql.gateway.serviceMap.working.setSchema(fullSchema)
-  const newSchema = await gateway.graphql.gateway.refresh()
+  gateway.graphqlGateway.serviceMap.working.setSchema(fullSchema)
+  const newSchema = await gateway.graphqlGateway.refresh()
 
   gateway.graphql.replaceSchema(newSchema)
 
@@ -529,8 +529,8 @@ test('Update the schema without any changes', async t => {
     }
   })
 
-  gateway.graphql.gateway.serviceMap.working.setSchema(schemaNode)
-  const newSchema = await gateway.graphql.gateway.refresh()
+  gateway.graphqlGateway.serviceMap.working.setSchema(schemaNode)
+  const newSchema = await gateway.graphqlGateway.refresh()
 
   t.equal(newSchema, null)
 })

--- a/test/subscription-hooks.js
+++ b/test/subscription-hooks.js
@@ -235,7 +235,7 @@ test('gateway subscription - hooks basic', async t => {
     }
   )
 
-  gateway.graphql.addHook(
+  gateway.graphql.gateway.addHook(
     'preGatewaySubscriptionExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -417,7 +417,7 @@ test('gateway - preSubscriptionExecution hooks should handle errors', async t =>
     t.fail('preSubscriptionExecution should not be called again')
   })
 
-  gateway.graphql.addHook('preGatewaySubscriptionExecution', async () => {
+  gateway.graphql.gateway.addHook('preGatewaySubscriptionExecution', async () => {
     t.fail('preGatewaySubscriptionExecution should not be called')
   })
 
@@ -469,10 +469,10 @@ test('gateway - preGatewaySubscriptionExecution hooks should handle errors', asy
   t.plan(2)
   const gateway = await createTestGatewayServer(t)
 
-  gateway.graphql.addHook('preGatewaySubscriptionExecution', async () => {
+  gateway.graphql.gateway.addHook('preGatewaySubscriptionExecution', async () => {
     throw new Error('a preGatewaySubscriptionExecution error occurred')
   })
-  gateway.graphql.addHook('preGatewaySubscriptionExecution', async () => {
+  gateway.graphql.gateway.addHook('preGatewaySubscriptionExecution', async () => {
     t.fail('preGatewaySubscriptionExecution should not be called again')
   })
 
@@ -523,7 +523,7 @@ test('gateway subscription - preGatewaySubscriptionExecution hooks should contai
 
   const subscriptionQuery = query('u1')
 
-  gateway.graphql.addHook(
+  gateway.graphql.gateway.addHook(
     'preGatewaySubscriptionExecution',
     async (schema, document, context, service) => {
       t.type(schema, GraphQLSchema)

--- a/test/subscription-hooks.js
+++ b/test/subscription-hooks.js
@@ -235,7 +235,7 @@ test('gateway subscription - hooks basic', async t => {
     }
   )
 
-  gateway.graphql.gateway.addHook(
+  gateway.graphqlGateway.addHook(
     'preGatewaySubscriptionExecution',
     async (schema, document, context) => {
       t.type(schema, GraphQLSchema)
@@ -417,7 +417,7 @@ test('gateway - preSubscriptionExecution hooks should handle errors', async t =>
     t.fail('preSubscriptionExecution should not be called again')
   })
 
-  gateway.graphql.gateway.addHook('preGatewaySubscriptionExecution', async () => {
+  gateway.graphqlGateway.addHook('preGatewaySubscriptionExecution', async () => {
     t.fail('preGatewaySubscriptionExecution should not be called')
   })
 
@@ -469,10 +469,10 @@ test('gateway - preGatewaySubscriptionExecution hooks should handle errors', asy
   t.plan(2)
   const gateway = await createTestGatewayServer(t)
 
-  gateway.graphql.gateway.addHook('preGatewaySubscriptionExecution', async () => {
+  gateway.graphqlGateway.addHook('preGatewaySubscriptionExecution', async () => {
     throw new Error('a preGatewaySubscriptionExecution error occurred')
   })
-  gateway.graphql.gateway.addHook('preGatewaySubscriptionExecution', async () => {
+  gateway.graphqlGateway.addHook('preGatewaySubscriptionExecution', async () => {
     t.fail('preGatewaySubscriptionExecution should not be called again')
   })
 
@@ -523,7 +523,7 @@ test('gateway subscription - preGatewaySubscriptionExecution hooks should contai
 
   const subscriptionQuery = query('u1')
 
-  gateway.graphql.gateway.addHook(
+  gateway.graphqlGateway.addHook(
     'preGatewaySubscriptionExecution',
     async (schema, document, context, service) => {
       t.type(schema, GraphQLSchema)

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,16 +1,17 @@
 import { expectAssignable, expectError } from 'tsd'
-import Fastify from 'fastify'
+import Fastify, { FastifyInstance } from 'fastify'
 import { MercuriusContext } from 'mercurius'
 
-import mercuriusGatewayPlugin from '../../index'
+import mercuriusGatewayPlugin, { MercuriusServiceMetadata } from '../../index'
+import { DocumentNode, GraphQLSchema } from 'graphql'
 
-const gateway = Fastify()
+const app = Fastify()
 
 expectError(() => {
-  gateway.register(mercuriusGatewayPlugin, {})
+  app.register(mercuriusGatewayPlugin, {})
 })
 
-gateway.register(mercuriusGatewayPlugin, {
+app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [
       {
@@ -80,7 +81,7 @@ gateway.register(mercuriusGatewayPlugin, {
 })
 
 // Async rewriteHeaders
-gateway.register(mercuriusGatewayPlugin, {
+app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [
       {
@@ -103,7 +104,7 @@ gateway.register(mercuriusGatewayPlugin, {
 })
 
 // keepAlive value in service config
-gateway.register(mercuriusGatewayPlugin, {
+app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [
       {
@@ -119,7 +120,7 @@ gateway.register(mercuriusGatewayPlugin, {
   }
 })
 
-gateway.register(mercuriusGatewayPlugin, {
+app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [
       {
@@ -135,7 +136,7 @@ gateway.register(mercuriusGatewayPlugin, {
   }
 })
 
-expectError(() => gateway.register(mercuriusGatewayPlugin, {
+expectError(() => app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [
       {
@@ -151,7 +152,7 @@ expectError(() => gateway.register(mercuriusGatewayPlugin, {
   }
 }))
 
-expectError(() => gateway.register(mercuriusGatewayPlugin, {
+expectError(() => app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [
       {
@@ -167,7 +168,7 @@ expectError(() => gateway.register(mercuriusGatewayPlugin, {
   }
 }))
 
-expectError(() => gateway.register(mercuriusGatewayPlugin, {
+expectError(() => app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [
       {
@@ -184,7 +185,7 @@ expectError(() => gateway.register(mercuriusGatewayPlugin, {
 }))
 
 // Gateway mode with load balanced services
-gateway.register(mercuriusGatewayPlugin, {
+app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [
       {
@@ -200,7 +201,7 @@ gateway.register(mercuriusGatewayPlugin, {
 })
 
 // Gateway mode with custom services retry props
-gateway.register(mercuriusGatewayPlugin, {
+app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [
       {
@@ -213,7 +214,7 @@ gateway.register(mercuriusGatewayPlugin, {
   }
 })
 
-expectError(() => gateway.register(mercuriusGatewayPlugin, {
+expectError(() => app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [
       {
@@ -225,3 +226,71 @@ expectError(() => gateway.register(mercuriusGatewayPlugin, {
     retryServicesInterval: '5000'
   }
 }))
+
+app.graphqlGateway.addHook('preGatewayExecution', async function (schema, document, context) {
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
+  return {
+    document,
+    errors: [
+      new Error('foo')
+    ]
+  }
+})
+
+app.graphqlGateway.addHook('preGatewayExecution', function (schema, document, context) {
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
+  return {
+    document,
+    errors: [
+      new Error('foo')
+    ]
+  }
+})
+
+app.graphqlGateway.addHook('preGatewayExecution', function (schema, document, context) {
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
+})
+
+app.graphqlGateway.addHook('preGatewaySubscriptionExecution', async function (schema, document, context) {
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
+})
+
+app.graphqlGateway.addHook('preGatewaySubscriptionExecution', function (schema, document, context) {
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
+})
+
+// Hooks containing service metadata
+app.graphqlGateway.addHook('preGatewayExecution', async function (schema, document, context, service) {
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
+  expectAssignable<MercuriusServiceMetadata>(service)
+})
+
+app.graphqlGateway.addHook('preGatewaySubscriptionExecution', async function (schema, document, context, service) {
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
+  expectAssignable<MercuriusServiceMetadata>(service)
+})
+
+// GraphQL Application lifecycle hooks
+app.graphqlGateway.addHook('onGatewayReplaceSchema', async function (instance, schema) {
+  expectAssignable<FastifyInstance>(instance)
+  expectAssignable<GraphQLSchema>(schema)
+})
+
+app.graphqlGateway.addHook('onGatewayReplaceSchema', function (instance, schema) {
+  expectAssignable<FastifyInstance>(instance)
+  expectAssignable<GraphQLSchema>(schema)
+})


### PR DESCRIPTION
This is a proposal for the `hooks` refactoring. 

It wprks without using mercurius internals.

Any feedback is appreciated!.

I've removed the reference to the mercurius/lib/errors a done some code replication that can be removed exporting the `error` object from mercurius.

there is still a reference to `mercurius/lib/subscription-client` that requires more code duplication and I decided to leave it there. 
If agreed I'll add the two exports from the `mercurius` modules to use it properly.

