### PR TITLE
fix: add test to cover query scalar return type

### DIFF
--- a/test/fix-33.js
+++ b/test/fix-33.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const plugin = require('../index')
+const createTestService = require('./utils/create-test-service')
+
+async function createTestGatewayServer (t) {
+  const [firstService, firstServicePort] = await createTestService(
+    t,
+    'extend type Query { countMe: Int! }',
+    { Query: { countMe: () => 42 } }
+  )
+
+  const [secondService, secondServicePort] = await createTestService(
+    t,
+    'extend type Query { noCountMe: Int! }',
+    { Query: { noCountMe: () => 13 } }
+  )
+
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+    await firstService.close()
+    await secondService.close()
+  })
+
+  await gateway.register(plugin, {
+    gateway: {
+      services: [
+        {
+          name: 'first',
+          url: `http://localhost:${firstServicePort}/graphql`
+        },
+        {
+          name: 'second',
+          url: `http://localhost:${secondServicePort}/graphql`
+        }
+      ]
+    }
+  })
+
+  return gateway
+}
+
+test('query returns a scalar type', async t => {
+  t.plan(1)
+  const app = await createTestGatewayServer(t)
+
+  const query = 'query { countMe noCountMe }'
+
+  const res = await app.inject({
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    url: '/graphql',
+    body: JSON.stringify({ query })
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      countMe: 42,
+      noCountMe: 13
+    }
+  })
+})

--- a/test/utils/create-test-service.js
+++ b/test/utils/create-test-service.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const Fastify = require('fastify')
+const GQL = require('mercurius')
+const { buildFederationSchema } = require('@mercuriusjs/federation')
+
+async function createTestService (t, schema, resolvers = {}) {
+  const service = Fastify()
+
+  service.register(GQL, {
+    schema: buildFederationSchema(schema),
+    resolvers
+  })
+  await service.listen({ port: 0 })
+
+  return [service, service.server.address().port]
+}
+
+module.exports = createTestService


### PR DESCRIPTION
I've added a test to cover this issue: https://github.com/mercurius-js/mercurius-gateway/issues/33

The feature works as expected. 
