### PR TITLE
fix: avoid not required calls

### DIFF
--- a/lib/gateway/build-gateway.js
+++ b/lib/gateway/build-gateway.js
@@ -292,7 +292,8 @@ function defineResolvers (
                 transformData: response =>
                   response.json.data._entities[0][fieldName],
                 entityResolversFactory,
-                lruGatewayResolvers
+                lruGatewayResolvers,
+                skipRequestIfValueExists: true
               })
             }
           }

--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -460,7 +460,8 @@ function makeResolver ({
   typeToServiceMap,
   serviceMap,
   entityResolversFactory,
-  lruGatewayResolvers
+  lruGatewayResolvers,
+  skipRequestIfValueExists
 }) {
   return async function (parent, args, context, info) {
     const {
@@ -490,6 +491,11 @@ function makeResolver ({
     let operation
     let query
     let selections
+
+    // verify and return the value if is already available in the parent
+    if (parent && parent[fieldName] && skipRequestIfValueExists) {
+      return parent[fieldName]
+    }
 
     if (cached) {
       variableNamesToDefine = cached.variableNamesToDefine
@@ -631,6 +637,7 @@ function makeResolver ({
       service.setResponseHeaders(reply || {})
 
       const transformed = transformData(response)
+
       // TODO support union types
       const transformedTypeName = Array.isArray(transformed)
         ? transformed.length > 0 && transformed[0].__typename
@@ -673,6 +680,30 @@ function makeResolver ({
           )
           query = appendFragments(query, fragmentsToDefine)
 
+          // TODO there are cases when the call is done even if is not required.
+          /*
+                    Eg.
+                        type Query @extends {
+                          userByPost(ids: [ID!]!): [User] @provides (fields: "id")
+                        }
+
+                      query { userByPost(ids: ["u1","u2"]) { id posts { pid } } }
+
+                    if the userByPost returns already the prefilled `post` attribute
+
+                    the call is done with this variables:
+                    {
+                      representations: [
+                        { __typename: 'User', id: 'u1' },
+                        { __typename: 'User', id: 'u2' }
+                      ]
+                    }
+
+                    and returns [ { __typename: 'User', id: 'u1' }, { __typename: 'User', id: 'u2' } ]
+
+                    A check on the content of the query that verifies that additional fields other than the key are required will improve the performance and avoid useless calls
+
+          */
           // We are completely skipping the resolver logic in this case to avoid expensive
           // multiple requests to the other service, one for each field. Our current logic
           // for the entities data loaders would not work in this case as we would need to
@@ -686,12 +717,14 @@ function makeResolver ({
             context,
             id: queryId
           })
+
           const entities = response2.json.data._entities
           for (let i = 0; i < entities.length; i++) {
             Object.assign(toFill[i], entities[i])
           }
         }
       }
+
       return transformed
     }
 

--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -669,7 +669,10 @@ function makeResolver ({
             variableDefinitions: []
           })
 
-          query = print(operation)
+          const existingValues = Object.keys(variables.representations[0])
+          const fieldsInRequest = selections.map(sel => sel.name.value).filter(value => !existingValues.includes(value))
+
+          const queryBySelections = print(operation)
 
           const usedFragments = getFragmentNamesInSelection(selections)
           const fragmentsToDefine = collectFragmentsToInclude(
@@ -678,47 +681,29 @@ function makeResolver ({
             serviceMap[targetService],
             schema
           )
-          query = appendFragments(query, fragmentsToDefine)
+          const finalQuery = appendFragments(queryBySelections, fragmentsToDefine)
 
-          // TODO there are cases when the call is done even if is not required.
-          /*
-                    Eg.
-                        type Query @extends {
-                          userByPost(ids: [ID!]!): [User] @provides (fields: "id")
-                        }
+          let entities
+          if (!fieldsInRequest.length && finalQuery === queryBySelections) {
+            entities = variables.representations
+          } else {
+            // We are completely skipping the resolver logic in this case to avoid expensive
+            // multiple requests to the other service, one for each field. Our current logic
+            // for the entities data loaders would not work in this case as we would need to
+            // resolve each field individually. Therefore we are short-cricuiting it and
+            // just issuing the request. A different algorithm based on the graphql executor
+            // is possible but it would be significantly slower and difficult to prepare.
+            const response2 = await entityResolvers[`${targetService}Entity`]({
+              document: operation,
+              query: finalQuery,
+              variables,
+              context,
+              id: queryId
+            })
 
-                      query { userByPost(ids: ["u1","u2"]) { id posts { pid } } }
+            entities = response2.json.data._entities
+          }
 
-                    if the userByPost returns already the prefilled `post` attribute
-
-                    the call is done with this variables:
-                    {
-                      representations: [
-                        { __typename: 'User', id: 'u1' },
-                        { __typename: 'User', id: 'u2' }
-                      ]
-                    }
-
-                    and returns [ { __typename: 'User', id: 'u1' }, { __typename: 'User', id: 'u2' } ]
-
-                    A check on the content of the query that verifies that additional fields other than the key are required will improve the performance and avoid useless calls
-
-          */
-          // We are completely skipping the resolver logic in this case to avoid expensive
-          // multiple requests to the other service, one for each field. Our current logic
-          // for the entities data loaders would not work in this case as we would need to
-          // resolve each field individually. Therefore we are short-cricuiting it and
-          // just issuing the request. A different algorithm based on the graphql executor
-          // is possible but it would be significantly slower and difficult to prepare.
-          const response2 = await entityResolvers[`${targetService}Entity`]({
-            document: operation,
-            query,
-            variables,
-            context,
-            id: queryId
-          })
-
-          const entities = response2.json.data._entities
           for (let i = 0; i < entities.length; i++) {
             Object.assign(toFill[i], entities[i])
           }

--- a/test/fix-30.js
+++ b/test/fix-30.js
@@ -65,6 +65,7 @@ async function createTestGatewayServer (t) {
     {
       User: {
         __resolveReference: (user, args, context, info) => {
+          t.fail('should skip this')
           return users[user.id]
         }
       }

--- a/test/fix-30.js
+++ b/test/fix-30.js
@@ -1,0 +1,182 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const plugin = require('../index')
+const createTestService = require('./utils/create-test-service')
+
+const users = {
+  u1: {
+    id: 'u1',
+    name: 'John'
+  },
+  u2: {
+    id: 'u2',
+    name: 'Jane'
+  },
+  u3: {
+    id: 'u3',
+    name: 'Jack'
+  }
+}
+
+const posts = {
+  p1: {
+    pid: 'p1',
+    title: 'Post 1',
+    content: 'Content 1',
+    authorId: 'u1'
+  },
+  p2: {
+    pid: 'p2',
+    title: 'Post 2',
+    content: 'Content 2',
+    authorId: 'u2'
+  },
+  p3: {
+    pid: 'p3',
+    title: 'Post 3',
+    content: 'Content 3',
+    authorId: 'u1'
+  },
+  p4: {
+    pid: 'p4',
+    title: 'Post 4',
+    content: 'Content 4',
+    authorId: 'u2'
+  },
+  p5: {
+    pid: 'p5',
+    title: 'Post 5',
+    content: 'Apollo filters this one out. Mercurius filters it out, then calls __resolveReference for some reason. This causes it to call User.posts again (but this time without posts data). So it looks up posts again, but this time without the filter logic that was in place in the Query resolver.',
+    authorId: 'u1'
+  }
+}
+
+async function createTestGatewayServer (t) {
+  const [firstService, firstServicePort] = await createTestService(
+    t,
+    `
+    type User @key(fields: "id") {
+      id: ID!
+      name: String!
+    }
+  `,
+    {
+      User: {
+        __resolveReference: (user, args, context, info) => {
+          return users[user.id]
+        }
+      }
+    }
+  )
+
+  const [secondService, secondServicePort] = await createTestService(
+    t,
+    `
+    type Post @key(fields: "pid") {
+      pid: ID!
+      title: String
+      content: String
+      author: User
+    }
+    type Query @extends {
+      userByPost(ids: [ID!]!): [User] @provides (fields: "id")
+    }
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      name: String @external
+      posts: [Post]
+    }
+  `,
+    {
+      Post: {
+        __resolveReference: (post, args, context, info) => {
+          return posts[post.pid]
+        },
+        author: (post, args, context, info) => {
+          return {
+            __typename: 'User',
+            id: post.authorId
+          }
+        }
+      },
+      User: {
+        posts: (user, args, context, info) => {
+          if (user.posts) {
+            return user.posts
+          }
+          t.fail('Should not be called')
+          return Object.values(posts).filter(p => p.authorId === user.id)
+        }
+      },
+      Query: {
+        userByPost: (root, args, context, info) => {
+          const users = []
+          for (const id of args.ids) {
+            users.push({ id, posts: Object.values(posts).filter(p => p.authorId === id && p.pid !== 'p5') })
+          }
+          return users
+        }
+      }
+    }
+  )
+
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+    await firstService.close()
+    await secondService.close()
+  })
+
+  await gateway.register(plugin, {
+    gateway: {
+      services: [
+        {
+          name: 'first',
+          url: `http://localhost:${firstServicePort}/graphql`
+        },
+        {
+          name: 'second',
+          url: `http://localhost:${secondServicePort}/graphql`
+        }
+      ]
+    }
+  })
+
+  return gateway
+}
+
+test('query returns a scalar type', async t => {
+  t.plan(1)
+  const app = await createTestGatewayServer(t)
+
+  const query = 'query { userByPost(ids: ["u1","u2"]) { id posts { pid title content } } }'
+
+  const res = await app.inject({
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    url: '/graphql',
+    body: JSON.stringify({ query })
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      userByPost: [{
+        id: 'u1',
+        posts: [{ pid: 'p1', title: 'Post 1', content: 'Content 1' }, {
+          pid: 'p3',
+          title: 'Post 3',
+          content: 'Content 3'
+        }]
+      }, {
+        id: 'u2',
+        posts: [{ pid: 'p2', title: 'Post 2', content: 'Content 2' }, {
+          pid: 'p4',
+          title: 'Post 4',
+          content: 'Content 4'
+        }]
+      }]
+    }
+  })
+})

--- a/test/utils/create-test-service.js
+++ b/test/utils/create-test-service.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const Fastify = require('fastify')
+const GQL = require('mercurius')
+const { buildFederationSchema } = require('@mercuriusjs/federation')
+
+async function createTestService (t, schema, resolvers = {}) {
+  const service = Fastify()
+
+  service.register(GQL, {
+    schema: buildFederationSchema(schema),
+    resolvers
+  })
+  await service.listen({ port: 0 })
+
+  return [service, service.server.address().port]
+}
+
+module.exports = createTestService


### PR DESCRIPTION
https://github.com/mercurius-js/mercurius-gateway/issues/30

This pr improve the calls where are not required:

eg.
```
    type Query @extends {
      userByPost(ids: [ID!]!): [User] @provides (fields: "id")
    }
    extend type User @key(fields: "id") {
      id: ID! @external
      name: String @external
      posts: [Post]
    }
```

if `userByPosts` response already have the `posts` attribute populated it doesn't ask it again.

Another small improvement was added, the entity resolver is called only if there are required fields.

Eg it skip call like:

```
query EntitiesQuery($representations: [_Any!]!) {
  _entities(representations: $representations) {
    __typename
    ... on User {
      id
      __typename
    }
  }
}
```

if the `id` is a key and is already in the `variables`


