### PR TITLE
feat: replace subscription client with the standalone package

### DIFF
--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -164,6 +164,7 @@ async function buildServiceMap (serviceMap, services, errorHandler, log) {
 
           const wsOpts = await getWsOpts(service)
           const client = new SubscriptionClient(service.wsUrl, wsOpts)
+
           client.connect()
           serviceConfig.client = client
           serviceConfig.createSubscription =

--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -14,8 +14,7 @@ const {
 
 const { buildRequest, sendRequest } = require('./request')
 
-// TODO: export subscription client from Mercurius to avoid an internal reference
-const SubscriptionClient = require('mercurius/lib/subscription-client')
+const { SubscriptionClient } = require('@mercuriusjs/subscription-client')
 const { MER_ERR_GQL_GATEWAY_INIT } = require('../errors')
 const { buildFederationSchema } = require('@mercuriusjs/federation')
 const { hasDirective, hasExtensionDirective } = require('../util')
@@ -165,7 +164,7 @@ async function buildServiceMap (serviceMap, services, errorHandler, log) {
 
           const wsOpts = await getWsOpts(service)
           const client = new SubscriptionClient(service.wsUrl, wsOpts)
-
+          client.connect()
           serviceConfig.client = client
           serviceConfig.createSubscription =
             client.createSubscription.bind(client)
@@ -210,6 +209,7 @@ async function buildServiceMap (serviceMap, services, errorHandler, log) {
     if (service.wsUrl) {
       const wsOpts = await getWsOpts(service)
       const client = new SubscriptionClient(service.wsUrl, wsOpts)
+      client.connect()
       serviceConfig.client = client
       serviceConfig.createSubscription = client.createSubscription.bind(client)
     }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@mercuriusjs/federation": "^0.1.0",
+    "@mercuriusjs/subscription-client": "^0.1.0",
     "fastify-plugin": "^4.3.0",
     "graphql": "^16.6.0",
     "graphql-ws": "^5.11.2",


### PR DESCRIPTION
replaced internal mercurius subscription client with the new package subscription client. 
`connect()` now has to be explicited