### PR TITLE
test: fix flaky tests

### DIFF
--- a/test/retry-failed-services.js
+++ b/test/retry-failed-services.js
@@ -399,14 +399,12 @@ test('gateway - should log error if retry throws', async t => {
       postService.schema,
       postService.resolvers
     )
-  }, 2000)
+  }, 500)
 
   const gateway = Fastify()
 
-  let errCount = 0
   gateway.log.error = error => {
-    if (error.message.includes('kaboom') && errCount === 0) {
-      errCount++
+    if (error.message.includes('kaboom')) {
       t.pass()
     }
   }
@@ -431,7 +429,7 @@ test('gateway - should log error if retry throws', async t => {
           mandatory: true
         }
       ],
-      retryServicesCount: 2,
+      retryServicesCount: 1,
       retryServicesInterval: 3000
     },
     jit: 1

--- a/test/retry-failed-services.js
+++ b/test/retry-failed-services.js
@@ -399,7 +399,7 @@ test('gateway - should log error if retry throws', async t => {
       postService.schema,
       postService.resolvers
     )
-  }, 500)
+  }, 2000)
 
   const gateway = Fastify()
 
@@ -432,7 +432,7 @@ test('gateway - should log error if retry throws', async t => {
         }
       ],
       retryServicesCount: 1,
-      retryServicesInterval: 3000
+      retryServicesInterval: 4000
     },
     jit: 1
   })

--- a/test/retry-failed-services.js
+++ b/test/retry-failed-services.js
@@ -431,8 +431,8 @@ test('gateway - should log error if retry throws', async t => {
           mandatory: true
         }
       ],
-      retryServicesCount: 1,
-      retryServicesInterval: 4000
+      retryServicesCount: 2,
+      retryServicesInterval: 3000
     },
     jit: 1
   })

--- a/test/retry-failed-services.js
+++ b/test/retry-failed-services.js
@@ -392,13 +392,14 @@ test('gateway - should log error if retry throws', async t => {
   )
 
   let service2 = null
+
   t.context.clock.setTimeout(async () => {
     service2 = await createTestService(
       5114,
       postService.schema,
       postService.resolvers
     )
-  }, 1000)
+  }, 500)
 
   const gateway = Fastify()
 

--- a/test/retry-failed-services.js
+++ b/test/retry-failed-services.js
@@ -398,7 +398,7 @@ test('gateway - should log error if retry throws', async t => {
       postService.schema,
       postService.resolvers
     )
-  }, 2000)
+  }, 1000)
 
   const gateway = Fastify()
 


### PR DESCRIPTION
resolves: https://github.com/mercurius-js/mercurius-gateway/issues/53
I'll try to fix flakiness of some tests.
On this one I think its the timers
https://github.com/mercurius-js/mercurius-gateway/blob/eddd8be095090cc0ee69688cc28e3518df21540b/test/retry-failed-services.js#L385-L448 
