### PR TITLE
feat: dynamic services function option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ app.register(mercuriusGateway, {
 - all the mercurius plugin [options](https://mercurius.dev/#/docs/api/options?id=plugin-options)
 - `gateway`: Object. Run the GraphQL server in gateway mode.
 
-  - `gateway.services`: Service[] An array of GraphQL services that are part of the gateway
+  - `gateway.services`: Service[] An array of GraphQL services that are part of the gateway. Alternative a `Function` that returns a `Promise` that resolves to an array of services. Required.
     - `service.name`: A unique name for the service. Required.
     - `service.url`: The URL of the service endpoint. It can also be an `Array` of URLs and in which case all the requests will be load balanced throughout the URLs. Required.
     - `service.mandatory`: `Boolean` Marks service as mandatory. If any of the mandatory services are unavailable, gateway will exit with an error. (Default: `false`)
@@ -213,6 +213,7 @@ app.register(mercuriusGateway, {
        - `collectors.collectExtensions`: `boolean` Adds to `context` the `collectors.extensions` object in which are stored the extensions field of the response from federated services.
   - `gateway.retryServicesCount`: `Number` Specifies the maximum number of retries when a service fails to start on gateway initialization. (Default: 10)
   - `gateway.retryServicesInterval`: `Number` The amount of time(in milliseconds) between service retry attempts in case a service fails to start on gateway initialization. (Default: 3000)
+  - `gateway.pollingInterval`: `Number` The amount of time(in milliseconds) between polling the services for schema updates. If not specified, the gateway will not poll for schema updates. (Default: `undefined`). When `gateway.services` is a function, the list of services is updated with the result of the function every `gateway.pollingInterval` milliseconds.
 
 ## Hooks
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,7 @@ export interface MercuriusGatewayService {
 
 export interface MercuriusGatewayOptions {
   gateway: {
-    services: Array<MercuriusGatewayService> | (() => Array<MercuriusGatewayService>);
+    services: Array<MercuriusGatewayService> | (() => Promise<Array<MercuriusGatewayService>>);
     pollingInterval?: number;
     errorHandler?(error: Error, service: MercuriusGatewayService): void;
     retryServicesCount?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,7 @@ export interface MercuriusGatewayService {
 
 export interface MercuriusGatewayOptions {
   gateway: {
-    services: Array<MercuriusGatewayService>;
+    services: Array<MercuriusGatewayService> | (() => Array<MercuriusGatewayService>);
     pollingInterval?: number;
     errorHandler?(error: Error, service: MercuriusGatewayService): void;
     retryServicesCount?: number;

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -18,6 +18,8 @@ const kGatewayHooks = Symbol('mercurius.gateway.hooks')
 function validateGateway (opts) {
   const gateway = opts
 
+  if (gateway.services instanceof Function) return
+
   if (Array.isArray(gateway.services)) {
     const serviceNames = new Set()
     for (const service of gateway.services) {

--- a/lib/gateway/build-gateway.js
+++ b/lib/gateway/build-gateway.js
@@ -525,11 +525,7 @@ async function buildGateway (serviceMap, gatewayOpts, app, lruGatewayResolvers) 
         const addedServices = newServices.filter(({ name }) => !oldServices.includes(name))
         const deletedServices = oldServices.filter(name => !newServices.find(service => service.name === name))
         for (const name of deletedServices) {
-          serviceMap[name]
-            .close()
-            .catch(
-              // istanbul ignore next
-              () => {})
+          serviceMap[name].close().catch(() => {})
           delete serviceMap[name]
         }
         await buildServiceMap(serviceMap, addedServices, errorHandler, app.log)

--- a/lib/gateway/build-gateway.js
+++ b/lib/gateway/build-gateway.js
@@ -523,7 +523,13 @@ async function buildGateway (serviceMap, gatewayOpts, app, lruGatewayResolvers) 
         const newServices = await this.serviceFn()
         const oldServices = Object.keys(serviceMap)
         const addedServices = newServices.filter(({ name }) => !oldServices.includes(name))
-        oldServices.forEach(name => { if (!newServices.find(service => service.name === name)) delete serviceMap[name] })
+        const deletedServices = oldServices.filter(name => !newServices.find(service => service.name === name))
+        for (const name of deletedServices) {
+          if (serviceMap[name].close) {
+            await serviceMap[name].close()
+          }
+          delete serviceMap[name]
+        }
         await buildServiceMap(serviceMap, addedServices, errorHandler, app.log)
       }
 

--- a/lib/gateway/build-gateway.js
+++ b/lib/gateway/build-gateway.js
@@ -525,9 +525,7 @@ async function buildGateway (serviceMap, gatewayOpts, app, lruGatewayResolvers) 
         const addedServices = newServices.filter(({ name }) => !oldServices.includes(name))
         const deletedServices = oldServices.filter(name => !newServices.find(service => service.name === name))
         for (const name of deletedServices) {
-          if (serviceMap[name].close) {
-            await serviceMap[name].close()
-          }
+          await serviceMap[name].close()
           delete serviceMap[name]
         }
         await buildServiceMap(serviceMap, addedServices, errorHandler, app.log)

--- a/lib/gateway/build-gateway.js
+++ b/lib/gateway/build-gateway.js
@@ -357,7 +357,11 @@ function defaultErrorHandler (error, service) {
 async function buildGateway (serviceMap, gatewayOpts, app, lruGatewayResolvers) {
   const { services, errorHandler = defaultErrorHandler } = gatewayOpts
 
-  await buildServiceMap(serviceMap, services, errorHandler, app.log)
+  if (services instanceof Function) {
+    await buildServiceMap(serviceMap, await services(), errorHandler, app.log)
+  } else {
+    await buildServiceMap(serviceMap, services, errorHandler, app.log)
+  }
 
   const serviceSDLs = Object.entries(serviceMap).reduce(
     (acc, [name, value]) => {
@@ -508,10 +512,19 @@ async function buildGateway (serviceMap, gatewayOpts, app, lruGatewayResolvers) 
     serviceMap,
     entityResolversFactory: factory,
     pollingInterval: gatewayOpts.pollingInterval,
+    serviceFn: gatewayOpts.services instanceof Function ? gatewayOpts.services : undefined,
     async refresh (isRetry) {
       const failedMandatoryServices = []
       if (this._serviceSDLs === undefined) {
         this._serviceSDLs = serviceSDLs.join(' ')
+      }
+
+      if (this.serviceFn) {
+        const newServices = await this.serviceFn()
+        const oldServices = Object.keys(serviceMap)
+        const addedServices = newServices.filter(({ name }) => !oldServices.includes(name))
+        oldServices.forEach(name => { if (!newServices.find(service => service.name === name)) delete serviceMap[name] })
+        await buildServiceMap(serviceMap, addedServices, errorHandler, app.log)
       }
 
       const $refreshResult = await Promise.allSettled(

--- a/lib/gateway/build-gateway.js
+++ b/lib/gateway/build-gateway.js
@@ -525,7 +525,11 @@ async function buildGateway (serviceMap, gatewayOpts, app, lruGatewayResolvers) 
         const addedServices = newServices.filter(({ name }) => !oldServices.includes(name))
         const deletedServices = oldServices.filter(name => !newServices.find(service => service.name === name))
         for (const name of deletedServices) {
-          await serviceMap[name].close()
+          serviceMap[name]
+            .close()
+            .catch(
+              // istanbul ignore next
+              () => {})
           delete serviceMap[name]
         }
         await buildServiceMap(serviceMap, addedServices, errorHandler, app.log)

--- a/test/pollingInterval.js
+++ b/test/pollingInterval.js
@@ -14,6 +14,7 @@ const { buildFederationSchema } = require('@mercuriusjs/federation')
 const GQL = require('mercurius')
 const plugin = require('../index')
 
+t.plan(10)
 t.beforeEach(({ context }) => {
   context.clock = FakeTimers.install({
     shouldClearNativeTimers: true,

--- a/test/pollingInterval.js
+++ b/test/pollingInterval.js
@@ -1244,3 +1244,207 @@ test('Polling schemas (subscriptions should be handled)', async t => {
   await gateway.close()
   await userService.close()
 })
+
+test('Polling schemas (with dynamic services function', async (t) => {
+  const userService = Fastify()
+  const postService = Fastify()
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+    await userService.close()
+    await postService.close()
+  })
+
+  const user = {
+    id: 'u1',
+    name: 'John'
+  }
+
+  userService.register(GQL, {
+    schema: buildFederationSchema(`
+      extend type Query {
+        me: User
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        name: String!
+      }
+    `),
+    resolvers: {
+      Query: {
+        me: () => user
+      },
+      User: {
+        __resolveReference: (user) => user
+      }
+    }
+  })
+
+  await userService.listen({ port: 0 })
+
+  const userServicePort = userService.server.address().port
+
+  const posts = {
+    p1: {
+      pid: 'p1',
+      title: 'Post 1',
+      content: 'Content 1',
+      authorId: 'u1'
+    }
+  }
+
+  postService.register(GQL, {
+    schema: buildFederationSchema(`
+      type Post @key(fields: "pid") {
+        pid: ID!
+        author: User
+      }
+
+      extend type Query {
+        topPosts(count: Int): [Post]
+      }
+
+      type User @key(fields: "id") @extends {
+        id: ID! @external
+        topPosts(count: Int!): [Post]
+      }`),
+    resolvers: {
+      Post: {
+        __resolveReference: (post, args, context, info) => {
+          return posts[post.pid]
+        },
+        author: (post, args, context, info) => {
+          return {
+            __typename: 'User',
+            id: post.authorId
+          }
+        }
+      },
+      User: {
+        topPosts: (user, { count }, context, info) => {
+          return Object.values(posts)
+            .filter((p) => p.authorId === user.id)
+            .slice(0, count)
+        }
+      },
+      Query: {
+        topPosts: (root, { count = 2 }) => Object.values(posts).slice(0, count)
+      }
+    }
+  })
+
+  await postService.listen({ port: 0 })
+
+  const postServicePort = postService.server.address().port
+
+  const services = [
+    {
+      name: 'user',
+      url: `http://localhost:${userServicePort}/graphql`
+    }
+  ]
+
+  const servicesFn = async () => services
+  await gateway.register(plugin, {
+    gateway: {
+      services: servicesFn,
+      pollingInterval: 2000
+    }
+  })
+
+  const res = await gateway.inject({
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    url: '/graphql',
+    body: JSON.stringify({
+      query: `
+        query MainQuery {
+          me {
+            id
+            name
+          }
+        }
+      `
+    })
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      me: {
+        id: 'u1',
+        name: 'John'
+      }
+    }
+  })
+
+  const res2 = await gateway.inject({
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    url: '/graphql',
+    body: JSON.stringify({
+      query: `
+        query MainQuery {
+          topPosts {
+            pid
+          }
+        }
+      `
+    })
+  })
+
+  t.same(JSON.parse(res2.body), {
+    errors: [
+      {
+        message: 'Cannot query field "topPosts" on type "Query".',
+        locations: [{ line: 3, column: 11 }]
+      }
+    ],
+    data: null
+  })
+
+  services.push({
+    name: 'post',
+    url: `http://localhost:${postServicePort}/graphql`
+  })
+
+  for (let i = 0; i < 10; i++) {
+    await t.context.clock.tickAsync(200)
+  }
+
+  // We need the event loop to actually spin twice to
+  // be able to propagate the change
+  await immediate()
+  await immediate()
+
+  const res3 = await gateway.inject({
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    url: '/graphql',
+    body: JSON.stringify({
+      query: `
+        query MainQuery {
+          topPosts {
+            pid
+          }
+        }
+      `
+    })
+  })
+
+  t.same(JSON.parse(res3.body), {
+    data: {
+      topPosts: [
+        {
+          pid: 'p1'
+        }
+      ]
+    }
+  })
+})

--- a/test/pollingInterval.js
+++ b/test/pollingInterval.js
@@ -1413,12 +1413,13 @@ test('Polling schemas (with dynamic services function, service added)', async (t
     url: `http://localhost:${postServicePort}/graphql`
   })
 
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 15; i++) {
     await t.context.clock.tickAsync(200)
   }
 
-  // We need the event loop to actually spin twice to
+  // We need the event loop to actually spin thrice to
   // be able to propagate the change
+  await immediate()
   await immediate()
   await immediate()
 
@@ -1591,12 +1592,13 @@ test('Polling schemas (with dynamic services function, service deleted)', async 
 
   services.pop()
 
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 15; i++) {
     await t.context.clock.tickAsync(200)
   }
 
-  // We need the event loop to actually spin twice to
+  // We need the event loop to actually spin thrice to
   // be able to propagate the change
+  await immediate()
   await immediate()
   await immediate()
 

--- a/test/pollingInterval.js
+++ b/test/pollingInterval.js
@@ -1417,27 +1417,28 @@ test('Polling schemas (with dynamic services function, service added)', async (t
     await t.context.clock.tickAsync(200)
   }
 
-  // We need the event loop to actually spin twice to
-  // be able to propagate the change
-  await immediate()
-  await immediate()
+  let res3
 
-  const res3 = await gateway.inject({
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json'
-    },
-    url: '/graphql',
-    body: JSON.stringify({
-      query: `
+  while (res3?.statusCode !== 200) {
+    await immediate()
+
+    res3 = await gateway.inject({
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      url: '/graphql',
+      body: JSON.stringify({
+        query: `
         query MainQuery {
           topPosts {
             pid
           }
         }
       `
+      })
     })
-  })
+  }
 
   t.same(JSON.parse(res3.body), {
     data: {
@@ -1595,27 +1596,28 @@ test('Polling schemas (with dynamic services function, service deleted)', async 
     await t.context.clock.tickAsync(200)
   }
 
-  // We need the event loop to actually spin twice to
-  // be able to propagate the change
-  await immediate()
-  await immediate()
+  let res2
 
-  const res2 = await gateway.inject({
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json'
-    },
-    url: '/graphql',
-    body: JSON.stringify({
-      query: `
+  while (res2?.statusCode !== 400) {
+    await immediate()
+
+    res2 = await gateway.inject({
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      url: '/graphql',
+      body: JSON.stringify({
+        query: `
         query MainQuery {
           topPosts {
             pid
           }
         }
       `
+      })
     })
-  })
+  }
 
   t.same(JSON.parse(res2.body), {
     errors: [

--- a/test/pollingInterval.js
+++ b/test/pollingInterval.js
@@ -1245,7 +1245,7 @@ test('Polling schemas (subscriptions should be handled)', async t => {
   await userService.close()
 })
 
-test('Polling schemas (with dynamic services function', async (t) => {
+test('Polling schemas (with dynamic services function, service added)', async (t) => {
   const userService = Fastify()
   const postService = Fastify()
   const gateway = Fastify()
@@ -1446,5 +1446,183 @@ test('Polling schemas (with dynamic services function', async (t) => {
         }
       ]
     }
+  })
+})
+
+test('Polling schemas (with dynamic services function, service deleted)', async (t) => {
+  const userService = Fastify()
+  const postService = Fastify()
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+    await userService.close()
+    await postService.close()
+  })
+
+  const user = {
+    id: 'u1',
+    name: 'John'
+  }
+
+  userService.register(GQL, {
+    schema: buildFederationSchema(`
+      extend type Query {
+        me: User
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        name: String!
+      }
+    `),
+    resolvers: {
+      Query: {
+        me: () => user
+      },
+      User: {
+        __resolveReference: (user) => user
+      }
+    }
+  })
+
+  await userService.listen({ port: 0 })
+
+  const userServicePort = userService.server.address().port
+
+  const posts = {
+    p1: {
+      pid: 'p1',
+      title: 'Post 1',
+      content: 'Content 1',
+      authorId: 'u1'
+    }
+  }
+
+  postService.register(GQL, {
+    schema: buildFederationSchema(`
+      type Post @key(fields: "pid") {
+        pid: ID!
+        author: User
+      }
+
+      extend type Query {
+        topPosts(count: Int): [Post]
+      }
+
+      type User @key(fields: "id") @extends {
+        id: ID! @external
+        topPosts(count: Int!): [Post]
+      }`),
+    resolvers: {
+      Post: {
+        __resolveReference: (post, args, context, info) => {
+          return posts[post.pid]
+        },
+        author: (post, args, context, info) => {
+          return {
+            __typename: 'User',
+            id: post.authorId
+          }
+        }
+      },
+      User: {
+        topPosts: (user, { count }, context, info) => {
+          return Object.values(posts)
+            .filter((p) => p.authorId === user.id)
+            .slice(0, count)
+        }
+      },
+      Query: {
+        topPosts: (root, { count = 2 }) => Object.values(posts).slice(0, count)
+      }
+    }
+  })
+
+  await postService.listen({ port: 0 })
+
+  const postServicePort = postService.server.address().port
+
+  const services = [
+    {
+      name: 'user',
+      url: `http://localhost:${userServicePort}/graphql`
+    },
+    {
+      name: 'post',
+      url: `http://localhost:${postServicePort}/graphql`
+    }
+  ]
+
+  const servicesFn = async () => services
+  await gateway.register(plugin, {
+    gateway: {
+      services: servicesFn,
+      pollingInterval: 2000
+    }
+  })
+
+  const res = await gateway.inject({
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    url: '/graphql',
+    body: JSON.stringify({
+      query: `
+        query MainQuery {
+          topPosts {
+            pid
+          }
+        }
+      `
+    })
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      topPosts: [
+        {
+          pid: 'p1'
+        }
+      ]
+    }
+  })
+
+  services.pop()
+
+  for (let i = 0; i < 10; i++) {
+    await t.context.clock.tickAsync(200)
+  }
+
+  // We need the event loop to actually spin twice to
+  // be able to propagate the change
+  await immediate()
+  await immediate()
+
+  const res2 = await gateway.inject({
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    url: '/graphql',
+    body: JSON.stringify({
+      query: `
+        query MainQuery {
+          topPosts {
+            pid
+          }
+        }
+      `
+    })
+  })
+
+  t.same(JSON.parse(res2.body), {
+    errors: [
+      {
+        message: 'Cannot query field "topPosts" on type "Query".',
+        locations: [{ line: 3, column: 11 }]
+      }
+    ],
+    data: null
   })
 })

--- a/test/pollingInterval.js
+++ b/test/pollingInterval.js
@@ -1413,13 +1413,12 @@ test('Polling schemas (with dynamic services function, service added)', async (t
     url: `http://localhost:${postServicePort}/graphql`
   })
 
-  for (let i = 0; i < 15; i++) {
+  for (let i = 0; i < 10; i++) {
     await t.context.clock.tickAsync(200)
   }
 
-  // We need the event loop to actually spin thrice to
+  // We need the event loop to actually spin twice to
   // be able to propagate the change
-  await immediate()
   await immediate()
   await immediate()
 
@@ -1592,13 +1591,12 @@ test('Polling schemas (with dynamic services function, service deleted)', async 
 
   services.pop()
 
-  for (let i = 0; i < 15; i++) {
+  for (let i = 0; i < 10; i++) {
     await t.context.clock.tickAsync(200)
   }
 
-  // We need the event loop to actually spin thrice to
+  // We need the event loop to actually spin twice to
   // be able to propagate the change
-  await immediate()
   await immediate()
   await immediate()
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -136,6 +136,23 @@ app.register(mercuriusGatewayPlugin, {
   }
 })
 
+const servicesFn = () => [
+  {
+    name: 'user',
+    url: 'http://localhost:4001/graphql',
+    schema: `
+        type Query {
+          dogs: [Dog]
+        }`
+  }
+]
+
+app.register(mercuriusGatewayPlugin, {
+  gateway: {
+    services: servicesFn
+  }
+})
+
 expectError(() => app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -136,7 +136,7 @@ app.register(mercuriusGatewayPlugin, {
   }
 })
 
-const servicesFn = () => [
+const servicesFn = async () => [
   {
     name: 'user',
     url: 'http://localhost:4001/graphql',


### PR DESCRIPTION
Closes #51 

This PR attempts to extend the options of mercurius to be able to refresh the gateway with a dynamic list of services. The `services` option now accepts a function which will be called upon build and refresh.

The idea is to be able to have the gateway paired with a schema registry so that no redeployment is needed when the registry adds or removes a service.

Another option, if preferred could be to add a new option (`serviceFetcher` or similar) instead of extending the existing one.

Ideas for improvement are welcomed.

Thanks in advance.