### PR TITLE
fix: correct service map generation

### DIFF
--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -119,7 +119,7 @@ function safeBuildSchema (schemaDefinition) {
   try {
     return buildSchema(schemaDefinition)
   } catch (e) {
-    return buildFederationSchema(schemaDefinition, { isGateway: true })
+    return buildFederationSchema(schemaDefinition)
   }
 }
 

--- a/test/service-map.js
+++ b/test/service-map.js
@@ -84,7 +84,6 @@ async function createTestGatewayServer (t) {
 }
 
 test('should contain all the fields', async t => {
-  t.plan(2)
   const app = await createTestGatewayServer(t)
 
   const serviceMap = app.graphqlGateway.serviceMap

--- a/test/serviceMap.js
+++ b/test/serviceMap.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const GQL = require('mercurius')
+const plugin = require('../index')
+const { buildFederationSchema } = require('@mercuriusjs/federation')
+
+async function createTestService (t, schema, resolvers = {}) {
+  const service = Fastify()
+
+  service.register(GQL, {
+    schema: buildFederationSchema(schema),
+    resolvers
+  })
+  await service.listen({ port: 0 })
+
+  return [service, service.server.address().port]
+}
+
+async function createTestGatewayServer (t) {
+  // User service
+  const userExtendSchema = `
+    type Query @extends {
+      hello: String
+    }
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      name: String @external
+      numberOfPosts: Int @requires(fields: "id name")
+    }
+  `
+
+  const [userExtendService, userExtendServicePort] = await createTestService(
+    t,
+    userExtendSchema,
+    {}
+  )
+
+  // user service
+  const userServiceSchema = `    
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id"){
+      id: ID!
+      name: String!
+      fullName: String
+      friends: [User]
+    }
+    `
+
+  const [userService, userServicePort] = await createTestService(
+    t,
+    userServiceSchema,
+    {}
+  )
+
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+    await userExtendService.close()
+    await userService.close()
+  })
+
+  await gateway.register(plugin, {
+    gateway: {
+      services: [
+        {
+          name: 'userExtend',
+          url: `http://localhost:${userExtendServicePort}/graphql`
+        },
+        {
+          name: 'user',
+          url: `http://localhost:${userServicePort}/graphql`
+        }
+      ]
+    }
+  })
+
+  return gateway
+}
+
+test('should contain all the fields', async t => {
+  t.plan(2)
+  const app = await createTestGatewayServer(t)
+
+  const serviceMap = app.graphqlGateway.serviceMap
+
+  t.deepEqual(Object.keys(serviceMap.user.schema._typeMap.User._fields), ['id', 'name', 'fullName', 'friends'])
+  t.deepEqual(Object.keys(serviceMap.userExtend.schema._typeMap.User._fields), ['id', 'name', 'numberOfPosts'])
+})


### PR DESCRIPTION
In this PR:

* The service map in the gateway is now generated correctly.

Eg.

```
    extend type User @key(fields: "id") {
      id: ID! @external
      name: String @external
      numberOfPosts: Int @requires(fields: "id name")
    }
```

Adds 'id', 'name', 'numberOfPosts' to the service map type.

Before this fix the `externals` were stripped from the result.

The gateway worked fine because that values are not used in the `resolver` system but the tooling based on that values failed.

Eg. https://github.com/nearform/mercurius-federation-info

