### PR TITLE
fix missing options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,6 +107,9 @@ export interface MercuriusGatewayService {
     context: TContext
   ) => OutgoingHttpHeaders | Promise<OutgoingHttpHeaders>;
   connections?: number;
+  bodyTimeout?: number;
+  headersTimeout?: number;
+  maxHeaderSize?: number;
   keepAlive?: number;
   keepAliveMaxTimeout?: number;
   rejectUnauthorized?: boolean;

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -120,6 +120,57 @@ app.register(mercuriusGatewayPlugin, {
   }
 })
 
+// bodyTimeout value in service config
+app.register(mercuriusGatewayPlugin, {
+  gateway: {
+    services: [
+      {
+        name: 'user',
+        url: 'http://localhost:4001/graphql',
+        schema: `
+        type Query {
+          dogs: [Dog]
+        }`,
+        bodyTimeout: 60000
+      }
+    ]
+  }
+})
+
+// headersTimeout value in service config
+app.register(mercuriusGatewayPlugin, {
+  gateway: {
+    services: [
+      {
+        name: 'user',
+        url: 'http://localhost:4001/graphql',
+        schema: `
+        type Query {
+          dogs: [Dog]
+        }`,
+        headersTimeout: 60000
+      }
+    ]
+  }
+})
+
+// maxHeaderSize value in service config
+app.register(mercuriusGatewayPlugin, {
+  gateway: {
+    services: [
+      {
+        name: 'user',
+        url: 'http://localhost:4001/graphql',
+        schema: `
+        type Query {
+          dogs: [Dog]
+        }`,
+        maxHeaderSize: 32768
+      }
+    ]
+  }
+})
+
 app.register(mercuriusGatewayPlugin, {
   gateway: {
     services: [


### PR DESCRIPTION
Adds missing `bodyTimeout`, `headersTimeout`, and `maxHeaderSize` to `MercuriusGatewayOptions`.

Fixes https://github.com/mercurius-js/mercurius-gateway/issues/77