### PR TITLE
Handle gzip compression in response body

### DIFF
--- a/lib/gateway/request.js
+++ b/lib/gateway/request.js
@@ -4,6 +4,7 @@ const { BalancedPool, Pool } = require('undici')
 const { URL } = require('url')
 const { FederatedError } = require('../errors')
 const sJSON = require('secure-json-parse')
+const zlib = require('zlib')
 
 function agentOption (opts) {
   return {
@@ -89,7 +90,16 @@ function sendRequest (request, url, useSecureParse) {
         context: opts.context
       })
 
-      const data = await body.text()
+      let data
+      if (headers['content-encoding'] === 'gzip') {
+        // undici request() doesn't automaticlally decompress the body
+        // so we have to manually do it here:
+        const blob = await body.blob()
+        const buffer = await blob.arrayBuffer()
+        data = zlib.gunzipSync(buffer).toString('utf8')
+      } else {
+        data = await body.text()
+      }
       const json = (useSecureParse ? sJSON : JSON).parse(data.toString())
 
       if (json.errors && json.errors.length) {


### PR DESCRIPTION
undici request() does not decompress bodies, so the gateway must do it. This commit only implements gzip decompression because that is the most common. Note: this commit does not set `accept-encoding` and that is left the user of the gateway to decide to enable that by rewriting the request headers.