### PR TITLE
fix(tests): fix the pollingInterval test

### DIFF
--- a/test/pollingInterval.js
+++ b/test/pollingInterval.js
@@ -351,7 +351,7 @@ test("Polling schemas (if service is down, schema shouldn't be changed)", async 
     lastName: 'Doe'
   }
 
-  const userService = Fastify()
+  const userService = Fastify({ forceCloseConnections: true })
   const gateway = Fastify()
 
   t.teardown(async () => {


### PR DESCRIPTION
Not sure why this test started failing recently, but it's failing in main and PR branches in Node 18 and 20 (but not 16 for some reason). fastify is supposed to close idle connections when `close()` is called, but it's not doing that in the test for some unknown reason. Setting `forceCloseConnections: true` makes fastify forcibly close the sockets and shutdown even if the sockets aren't idle, which seems fine for this test.