### PR TITLE
Feat/gateway error handling exports

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,9 +4,9 @@ const fp = require('fastify-plugin')
 const GQL = require('mercurius')
 
 const { createGateway } = require('./gateway')
-const { defaultErrorFormatter } = require('./errors')
+const { defaultErrorFormatter, FederatedError } = require('./errors')
 
-module.exports = fp(async (fastify, opts) => {
+const plugin = fp(async (fastify, opts) => {
   const gateway = opts.gateway
   delete opts.gateway
 
@@ -19,3 +19,8 @@ module.exports = fp(async (fastify, opts) => {
   })
   await createGateway(gateway, fastify)
 })
+
+plugin.FederatedError = FederatedError
+plugin.defaultErrorFormatter = defaultErrorFormatter
+
+module.exports = plugin

--- a/test/errors.js
+++ b/test/errors.js
@@ -3,6 +3,86 @@
 const { GraphQLError } = require('graphql')
 const { test } = require('tap')
 const { FederatedError, defaultErrorFormatter } = require('../lib/errors')
+const GQL = require('mercurius')
+const Fastify = require('fastify')
+const plugin = require('../index')
+const { buildFederationSchema } = require('@mercuriusjs/federation')
+
+async function createTestService (
+  t,
+  schema,
+  resolvers = {}
+) {
+  const service = Fastify()
+  service.register(GQL, {
+    schema: buildFederationSchema(schema),
+    resolvers
+  })
+  await service.listen({ port: 0 })
+  return [service, service.server.address().port]
+}
+
+async function createTestGatewayServer (t, errorFormatter = undefined) {
+  // User service
+  const userServiceSchema = `
+  type Query @extends {
+    me: User
+  }
+
+  type Metadata {
+    info: String!
+  }
+
+  type User @key(fields: "id") {
+    id: ID!
+    name: String!
+    quote(input: String!): String!
+    metadata(input: String!): Metadata!
+  }`
+  const userServiceResolvers = {
+    Query: {
+      me: () => {
+        throw new Error('Invalid User ID', {
+          id: 4,
+          code: 'USER_ID_INVALID'
+        })
+      }
+    },
+    User: {
+      quote: () => {
+        throw new Error('Invalid Quote', {
+          id: 4,
+          code: 'QUOTE_ID_INVALID'
+        })
+      }
+    }
+  }
+  const [userService, userServicePort] = await createTestService(
+    t,
+    userServiceSchema,
+    userServiceResolvers
+  )
+
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+    await userService.close()
+  })
+
+  gateway.register(plugin, {
+    gateway: {
+      services: [
+        {
+          name: 'user',
+          url: `http://localhost:${userServicePort}/graphql`
+        }
+      ]
+    },
+    ...(errorFormatter ? { errorFormatter } : {})
+  })
+
+  return gateway
+}
 
 test('errors: FederatedError ', async t => {
   t.plan(1)
@@ -65,4 +145,36 @@ test('errors: defaultErrorFormatter with multiple errors', t => {
   })
 
   t.end()
+})
+
+test('errors - custom error formatter that uses default error formatter', async t => {
+  const app = await createTestGatewayServer(t, (err, ctx) => {
+    t.ok(ctx)
+    t.equal(ctx.app, app)
+    t.ok(ctx.reply)
+    const response = defaultErrorFormatter(err, ctx)
+    response.statusCode = 500
+    return response
+  })
+  const query = `
+    query {
+      user: me {
+        id
+      }
+    }`
+
+  await app.ready()
+
+  const res = await app.inject({
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    url: '/graphql',
+    body: JSON.stringify({ query })
+  })
+
+  await app.close()
+
+  const body = JSON.parse(res.body)
+  t.equal(res.statusCode, 500)
+  t.equal(body.errors[0].message, 'Invalid User ID')
 })


### PR DESCRIPTION
Added export of `defaultErrorFormatter` and `FederatedError` as it now differs from [mercurius](https://github.com/mercurius-js/mercurius). 

Reference: https://github.com/mercurius-js/mercurius/pull/942/files#diff-0af7067b49efcaf7dae9a3707f2e79638b336e72780d2b834e007f80ef9a5fa0